### PR TITLE
Improve flexibility of authors, affiliations input

### DIFF
--- a/agile-editing-pandoc.md
+++ b/agile-editing-pandoc.md
@@ -1,12 +1,15 @@
 ---
 title: 'Formatting Open Science: agile creation of multiple document types by writing academic manuscripts in pandoc markdown'
 author:
-  - name: Albert Krewinkel
-    institute: Pandoc Development Team
-  - name: Robert Winkler
-    institute: CINVESTAV Unidad Irapuato, Department of Biochemistry and Biotechnology, Irapuato-León, Mexico
-    fullname: Prof. Dr. Robert Winkler
-    email: robert.winkler@cinvestav.mx
+  - Albert Krewinkel:
+      institute: pdt
+  - Robert Winkler:
+      institute: cinvestav
+      fullname: Prof. Dr. Robert Winkler
+      email: robert.winkler@cinvestav.mx
+institute:
+  - cinvestav: CINVESTAV Unidad Irapuato, Department of Biochemistry and Biotechnology, Irapuato-León, Mexico
+  - pdt: "Pandoc Development Team"
 bibliography: agile-markdown.bib
 keywords: [open science, document formats, markdown, latex, publishing, typesetting]
 ---

--- a/scripts/affiliations.lua
+++ b/scripts/affiliations.lua
@@ -6,11 +6,8 @@ local abstract = {}
 local in_abstract = false
 
 function Doc(body, meta, variables)
-  -- Fragile, handle with care.  Order matters.
-  meta.author = panmeta.add_indices(panmeta.authors(meta))
-  meta.institute = panmeta.add_indices(
-    panmeta.as_names(panmeta.list_institutes(meta.author)))
-  panmeta.set_affiliation_indices(meta.author, meta.institute)
+  meta.author, meta.institute =
+    panmeta.canonicalize_authors(meta.author, meta.institute)
   if next(abstract) ~= nil then
     meta.abstract = abstract
   else

--- a/scripts/default.lua
+++ b/scripts/default.lua
@@ -6,19 +6,20 @@ local abstract = {}
 local in_abstract = false
 
 function Doc(body, meta, variables)
-  local authors = panmeta.authors(meta)
+  local authors, affiliations =
+    panmeta.canonicalize_authors(meta.author, meta.institute)
   meta.author = {}
   for k, author in ipairs(authors) do
     if author.institute and author.institute[1] then
       local inst = panlunatic.Space()
         .. panlunatic.Str('(')
-        .. author.institute[1]
+        .. author.institute[1].name
         .. panlunatic.Str(')')
       meta.author[k] = author.name .. inst
     else
       meta.author[k] = author.name
     end
   end
-  meta.institute = panmeta.list_institutes(authors)
+  meta.institute = affiliations:map(function(inst) return inst.name end)
   return panlunatic.Doc(body, meta, variables)
 end

--- a/scripts/panmeta.lua
+++ b/scripts/panmeta.lua
@@ -1,116 +1,148 @@
 local panmeta = {_version = "0.1.0"}
+local pretty = require("pl/pretty")
 
+local panlunatic = require "panlunatic"
 local is_equal -- forward declaration
 
-function panmeta.as_names(strings)
-  local objects = {}
-  for _, str in ipairs(strings) do
-    table.insert(objects, {name = str})
-  end
-  return objects
+local MetaObjectList = {}
+function MetaObjectList:new (item_class)
+  local o = {item_class = item_class}
+  setmetatable(o, self)
+  self.__index = self
+  return o
 end
-
--- Add indices to entries
-function panmeta.add_indices(objects)
-  for i, obj in ipairs(objects) do
-    obj.index = i
-  end
-  return objects
-end
-
--- author objects
-function panmeta.authors(metadata)
-  local authors = {}
-  for _, author in ipairs(metadata.author) do
-    if type(author) == "string" then
-      author = {name = author}
+function MetaObjectList:init (raw_list)
+  local meta_objects = {}
+  setmetatable(meta_objects, self)
+  self.__index = self
+  if type(raw_list) == "table" then
+    for i, raw_item in ipairs(raw_list) do
+      meta_objects[#meta_objects + 1] = self.item_class:canonicalize(raw_item, i)
     end
-
-    local institute = panmeta.names(author.institute)
-    if #institute > 0 then
-      author.institute = institute
-    end
-    table.insert(authors, author)
+    return meta_objects
+  else
+    meta_objects[1] = self.item_class:canonicalize(raw_list, 1)
+    return meta_objects
   end
-  return authors
 end
-
-function panmeta.names(objects)
-  -- FIXME: warn when no name could be found
-  if type(objects) == "string" then return {objects} end
-  if type(objects) ~= "table" then return {} end
-  if objects.name then return {objects.name} end
+function MetaObjectList:map (fn)
   local res = {}
-  for _, obj in ipairs(objects) do
-    panmeta.concat_table(res, panmeta.names(obj))
+  for k, v in ipairs(self) do
+    res[k] = fn(v)
   end
   return res
 end
-
-function panmeta.set_affiliation_indices(authors, institutes)
-  local affiliations = {}
-  function institute_index(needle)
-    for _, institute in pairs(institutes) do
-      if is_equal(needle, institute.name) then
-        return institute.index
-      end
-    end
-    error("Could not find instititute.  This should never happen.")
+function MetaObjectList:each (fn)
+  for k, v in pairs(self) do
+    fn(k, v)
   end
-
-  for ia, author in ipairs(authors) do
-    author.institute_indices = {}
-    for ii, institute in ipairs(author.institute) do
-      table.insert(author.institute_indices, institute_index(institute))
-    end
-  end
-  return authors
 end
 
-function panmeta.list_institutes(authors)
-  local institutes = {}
-  function add_institute(institute)
-    for _, inst in ipairs(institutes) do
-      if is_equal(inst, institute) then
-        return
-      end
+local NamedObject = {}
+function NamedObject:new (o)
+  local o = o or {}
+  setmetatable(o, self)
+  self.__index = self
+  return o
+end
+function NamedObject:canonicalize (raw_item, index)
+  local item = self:new{index = index}
+  if type(raw_item) ~= "table" then
+    item.name = tostring(raw_item)
+    item.abbreviation = tostring(raw_item)
+  elseif raw_item.name ~= nil then
+    for k, v in pairs(raw_item) do
+      item[k] = v
     end
-    table.insert(institutes, institute)
-  end
-
-  for _, author in ipairs(authors) do
-    if author.institute and next(author.institute) ~= nil then
-      for _, institute in ipairs(author.institute) do
-        add_institute(institute)
+  else
+    raw_name, item_attributes = next(raw_item)
+    item.name = panlunatic.Str(tostring(raw_name))
+    item.abbreviation = panlunatic.Str(tostring(raw_name))
+    if type(item_attributes) ~= "table" then
+      item.name = item_attributes
+    else
+      for k, v in pairs(item_attributes) do
+        item[k] = v
       end
     end
   end
-  return institutes
+  return item
 end
 
-function panmeta.concat_table(t1, t2)
-  for i = 1, #t2 do
-    t1[#t1 + 1] = t2[i]
+local Institute = NamedObject:new()
+local Institutes = MetaObjectList:new(Institute)
+
+local Author = NamedObject:new()
+local Authors = MetaObjectList:new(Author)
+function Authors:resolve_institutes (institutes)
+  function find_by_abbreviation(index)
+    for _, v in pairs(institutes) do
+      if v.abbreviation == index then
+        return v
+      end
+    end
   end
-  return t1
-end
-
-is_equal = function (x, y)
-  local tx = type(x)
-  local ty = type(y)
-  if tx ~= "table" and ty ~= "table" then return x == y end
-  if tx ~= ty then return false end
-  if x == y then return true end
-  if not are_keys_equal(x, y) then return false end
-  if not are_keys_equal(y, x) then return false end
-  return true
-end
-
-local function are_keys_equal(x, y)
-  for kx, vx in pairs(x) do
-    local vy = y[k1]
-    if vy == nil or not is_equal(vx, vy) then return false end
+  for i, author in ipairs(self) do
+    if author.institute ~= nil then
+      local authinst
+      if type(author.institute) == "string" or type(author.institute) == "number" then
+        authinst = {author.institute}
+      else
+        authinst = author.institute
+      end
+      local res = Institutes:init{}
+      for j, inst in ipairs(authinst) do
+        res[#res + 1] =
+          institutes[tonumber(inst)] or
+          find_by_abbreviation(inst) or
+          Institute:canonicalize(inst)
+      end
+      author.institute = res
+    end
   end
 end
 
-return panmeta
+--- Insert a named object into a list; if an object of the same name exists
+-- already, add all properties only present in the new object to the existing
+-- item.
+function insertMergeUniqueName (list, namedObj)
+  for _, obj in pairs(list) do
+    if obj.name == namedObj.name then
+      for k, v in pairs(namedObj) do
+        obj[k] = obj[k] or v
+      end
+      return obj
+    end
+  end
+  list[#list + 1] = namedObj
+  return namedObj
+end
+
+local function canonicalize_authors(raw_authors, raw_institutes)
+  local authors = Authors:init(raw_authors)
+  local all_institutes = Institutes:init(raw_institutes)
+  authors:resolve_institutes(all_institutes)
+
+  -- ordered affiliations
+  local affiliations = Institutes:init{}
+  authors:each(function (_, author)
+      for i, authinst in ipairs(author.institute) do
+        author.institute[i] = insertMergeUniqueName(affiliations, authinst)
+      end
+  end)
+  -- add indices to affiliations
+  affiliations:each(function (i, affl) affl.index = i end)
+  -- set institute_indices for all authors
+  authors:each(function (k, author)
+      author.institute_indices = author.institute:map(
+        function(inst) return inst.index end
+      )
+  end)
+  return authors, affiliations
+end
+
+return {
+  Authors = Authors,
+  Institutes = Institutes,
+  canonicalize_authors = canonicalize_authors,
+}


### PR DESCRIPTION
Specification of authors and their affiliations must be as simple and
intuitive as possible. Processing of the `author` and `institute` meta
fields is hence improved. The number of possible ways to input this data
is increased, improving flexibility and convenience for authors.

Meta data for authors and affiliations are uniformly treated as named
objects. Names can be given as a string, as via the key of a
single-element object, or explicitly as a `name` attribute of an
object. The following are hence equivalent:

    author:
      - John Doe:
          institute: Agile Science Society

    author:
      - name: John Doe
        institute: Agile Science Society

    author:
      - name: John Doe
        institute:
          - name: Agile Science Society

Institutes may be given separately. If `institute` is an object, the elements
therein can be referred to using their key.

    author:
      - John Doe:
          institute: agsci
    institute:
      agsci: Agile Science Society

If `institute` is an array, numeric indices can be used instead.

    author:
      - John Doe:
          institute: 1
    institute:
      - Agile Science Society

Scripts of the publishing pipeline are adapted accordingly.